### PR TITLE
Make ui smaller on smaller screens

### DIFF
--- a/assets/ui/ui.rml
+++ b/assets/ui/ui.rml
@@ -73,6 +73,34 @@
 			z-index: 100;
 			opacity: 1;
 			}
+
+			@media (max-width: 1300px)  {
+				body {
+					font-size: 20px;
+				}
+
+				.ui {
+					gap: 16px;
+					margin-bottom: 10px;
+				}
+
+				.points {
+					font-size: 60px;
+				}
+
+				h2 {
+					font-size: 22px;
+				}
+
+				.multiplier-container {
+					width: 45px;
+					height: 160px;
+				}
+
+				progress {
+					width: 42px;
+				}
+			}
 		</style>
 
         


### PR DESCRIPTION
- Need to set 2x width in responsive rule. So to make a breakpoint at 650px we need to set 1300px. Maybe caused by using sokol high-dpi mode?